### PR TITLE
issue #5:  Save the setting to each registry for each Visual Studio version

### DIFF
--- a/CopyWithLineNumbers/Configuration.cs
+++ b/CopyWithLineNumbers/Configuration.cs
@@ -10,22 +10,17 @@ namespace CopyWithLineNumbers
     /// <summary>
     /// Configuration and setting manager
     /// </summary>
-    class Configuration
+    public class Configuration
     {
         /// <summary>
-        /// Singleton for this class
+        /// root registry key for user setting
         /// </summary>
-        private static volatile Configuration instance;
-
-        /// <summary>
-        /// Lock Object
-        /// </summary>
-        private static object syncRoot = new Object();
+        private RegistryKey UserRegistryRoot;
 
         /// <summary>
         /// Registry SubKey for the setting
         /// </summary>
-        private const string SubKeyName = @"SOFTWARE\mtmatma\CopyWithLineNumbers";
+        private const string SubKeyName = @"CopyWithLineNumbers";
 
         /// <summary>
         /// Registry Value Name for FormatString setting
@@ -40,23 +35,10 @@ namespace CopyWithLineNumbers
         /// <summary>
         /// Property for getting singleton instance
         /// </summary>
-        public static Configuration Instance
+        /// <param name="userRegistryRoot">root Registry for User setting</param>
+        public Configuration(RegistryKey userRegistryRoot)
         {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (syncRoot)
-                    {
-                        if (instance == null)
-                        {
-                            instance = new Configuration();
-                            instance.Load();
-                        }
-                    }
-                }
-                return instance;
-            }
+            this.UserRegistryRoot = userRegistryRoot;
         }
  
         /// <summary>
@@ -68,20 +50,15 @@ namespace CopyWithLineNumbers
             this.FormatString = DefaultFormatString;
             try
             {
-                RegistryKey rKey = Registry.CurrentUser.OpenSubKey(SubKeyName);
-
-                try
+                using (RegistryKey subKey = this.UserRegistryRoot.OpenSubKey(SubKeyName))
                 {
-                    var value = (string)rKey.GetValue(ValueNameFormatString, DefaultFormatString);
+                    var value = (string)subKey.GetValue(ValueNameFormatString, DefaultFormatString);
                     this.FormatString = value;
                 }
-                catch (NullReferenceException)
-                {
-                }
-                rKey.Close();
             }
             catch (NullReferenceException)
             {
+                ;
             }
         }
 
@@ -92,19 +69,14 @@ namespace CopyWithLineNumbers
         {
             try
             {
-                RegistryKey rKey = Registry.CurrentUser.CreateSubKey(SubKeyName);
-
-                try
+                using (RegistryKey subKey = this.UserRegistryRoot.CreateSubKey(SubKeyName))
                 {
-                    rKey.SetValue(ValueNameFormatString, this.FormatString);
+                    subKey.SetValue(ValueNameFormatString, this.FormatString);
                 }
-                catch (NullReferenceException)
-                {
-                }
-                rKey.Close();
             }
             catch (NullReferenceException)
             {
+                ;
             }
         }
     }

--- a/CopyWithLineNumbers/CopyWithLineNumbersCommand.cs
+++ b/CopyWithLineNumbers/CopyWithLineNumbersCommand.cs
@@ -51,7 +51,7 @@ namespace CopyWithLineNumbers
                 command.Visible = false;
                 if (activeDocument != null)
                 {
-                    var configuration = Configuration.Instance;
+                    var configuration = this.package.GetConfiguration();
                     var selection = (EnvDTE.TextSelection)activeDocument.Selection;
                     if (!selection.IsEmpty)
                     {
@@ -252,7 +252,7 @@ namespace CopyWithLineNumbers
             if (activeDocument != null)
             {
                 var values = CreateValuesDictionary();
-                var configuration = Configuration.Instance;
+                var configuration = this.package.GetConfiguration();
                 var formatString = configuration.FormatString;
 
                 var copyString = Template.ProcessTemplate(formatString, values);

--- a/CopyWithLineNumbers/OptionsControl.cs
+++ b/CopyWithLineNumbers/OptionsControl.cs
@@ -17,7 +17,6 @@ namespace CopyWithLineNumbers
         public OptionsControl()
         {
             InitializeComponent();
-            this.LoadSetting();
 
             foreach(VariableManager variableName in Template.Variables)
             {
@@ -41,16 +40,22 @@ namespace CopyWithLineNumbers
             }
         }
 
-        public void SaveSetting()
+        /// <summary>
+        /// Save the setting to the registry
+        /// </summary>
+        /// <param name="configuration"></param>
+        public void SaveSetting(Configuration configuration)
         {
-            var configuration = Configuration.Instance;
             configuration.FormatString = this.textBoxTemplate.Text;
             configuration.Save();
         }
 
-        public void LoadSetting()
+        /// <summary>
+        /// Load the setting from the registry
+        /// </summary>
+        /// <param name="configuration"></param>
+        public void LoadSetting(Configuration configuration)
         {
-            var configuration = Configuration.Instance;
             this.textBoxTemplate.Text = configuration.FormatString;
         }
 

--- a/CopyWithLineNumbers/OptionsPageSetting.cs
+++ b/CopyWithLineNumbers/OptionsPageSetting.cs
@@ -26,6 +26,10 @@ namespace CopyWithLineNumbers
                     optionsControl = new OptionsControl();
                     optionsControl.Location = new Point(0, 0);
                     optionsControl.OptionsPage = this;
+
+                    VSPackage package = GetService(typeof(VSPackage)) as VSPackage;
+                    var configuration = package.GetConfiguration();
+                    optionsControl.LoadSetting(configuration);
                 }
                 return optionsControl;
             }
@@ -54,7 +58,10 @@ namespace CopyWithLineNumbers
         /// </devdoc>
         protected override void OnApply(PageApplyEventArgs e)
         {
-            this.optionsControl.SaveSetting();
+            VSPackage package = GetService(typeof(VSPackage)) as VSPackage;
+            var configuration = package.GetConfiguration();
+
+            this.optionsControl.SaveSetting(configuration);
         }
     }
 }

--- a/CopyWithLineNumbers/VSPackage.cs
+++ b/CopyWithLineNumbers/VSPackage.cs
@@ -45,6 +45,11 @@ namespace CopyWithLineNumbers
     public sealed class VSPackage : Package
     {
         /// <summary>
+        /// configuration class
+        /// </summary>
+        private Configuration configuration;
+
+        /// <summary>
         /// VSPackage GUID string.
         /// </summary>
         public const string PackageGuidString = "c43ac2b7-f6f8-4fb9-a537-eeb29a7a03eb";
@@ -94,8 +99,6 @@ namespace CopyWithLineNumbers
         /// <returns></returns>
         public Configuration GetConfiguration()
         {
-            var configuration = new Configuration(this.UserRegistryRoot);
-            configuration.Load();
             return configuration;
         }
 
@@ -118,6 +121,9 @@ namespace CopyWithLineNumbers
 #if DEBUG
             AddOutputWindow("Copy With Line Numbers");
 #endif
+
+            this.configuration = new Configuration(this.UserRegistryRoot);
+            this.configuration.Load();
         }
 
         #endregion

--- a/CopyWithLineNumbers/VSPackage.cs
+++ b/CopyWithLineNumbers/VSPackage.cs
@@ -89,6 +89,17 @@ namespace CopyWithLineNumbers
 #endif
 
         /// <summary>
+        /// Get Instance of Configuration
+        /// </summary>
+        /// <returns></returns>
+        public Configuration GetConfiguration()
+        {
+            var configuration = new Configuration(this.UserRegistryRoot);
+            configuration.Load();
+            return configuration;
+        }
+
+        /// <summary>
         /// Property For OutputWindow
         /// </summary>
         public EnvDTE.OutputWindowPane OutputPane { get; private set; }


### PR DESCRIPTION
Save the setting to each registry for each Visual Studio version.
This makes it possible to save the different settings for Visual Studio 2015 and 2017.